### PR TITLE
Changed pushrelease workflow for minor bump

### DIFF
--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          DEFAULT_BUMP: patch
+          DEFAULT_BUMP: minor
 
       - name: Checkout two
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Changed pushrelease workflow default bump to minor so that Github bumps to the right version number. For more information on this release, please see #53 and #55.